### PR TITLE
Fix UDF build issues that affect Hive 2.x releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,17 @@
                                                 <goals>
                                                         <goal>shade</goal>
                                                 </goals>
+                                                <configuration>
+                                                        <relocations>
+                                                                <relocation>
+                                                                        <pattern>com.fasterxml.jackson</pattern>
+                                                                        <shadedPattern>com.shaded.fasterxml.jackson</shadedPattern>
+                                                                        <includes>
+                                                                                <include>com.fasterxml.jackson.**</include>
+                                                                        </includes>
+                                                                </relocation>
+                                                        </relocations>
+                                                </configuration>
                                         </execution>
                                 </executions>
                         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,6 @@
                         <scope>provided</scope>
                 </dependency>
                 <dependency>
-                        <groupId>javax.jdo</groupId>
-                        <artifactId>jdo2-api</artifactId>
-                        <version>2.3-20090302111651</version>
-                        <scope>provided</scope>
-                </dependency>
-                <dependency>
                         <groupId>com.maxmind.geoip2</groupId>
                         <artifactId>geoip2</artifactId>
                         <version>2.12.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
                                                                                 <include>com.fasterxml.jackson.**</include>
                                                                         </includes>
                                                                 </relocation>
+                                                                <relocation>
+                                                                        <pattern>com.maxmind</pattern>
+                                                                        <shadedPattern>com.shaded.maxmind</shadedPattern>
+                                                                        <includes>
+                                                                                <include>com.maxmind.**</include>
+                                                                        </includes>
+                                                                </relocation>
                                                         </relocations>
                                                 </configuration>
                                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
                         <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.8.1</version>
                                 <configuration>
                                         <source>1.7</source>
                                         <target>1.7</target>
@@ -26,6 +27,7 @@
                         <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-shade-plugin</artifactId>
+                                <version>3.2.1</version>
                                 <executions>
                                         <execution>
                                                 <phase>package</phase>
@@ -41,13 +43,13 @@
                 <dependency>
                         <groupId>org.apache.hive</groupId>
                         <artifactId>hive-exec</artifactId>
-                        <version>0.10.0</version>
+                        <version>2.3.3</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>
                         <groupId>org.apache.hadoop</groupId>
                         <artifactId>hadoop-core</artifactId>
-                        <version>1.1.1</version>
+                        <version>1.2.1</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>
@@ -59,7 +61,7 @@
                 <dependency>
                         <groupId>com.maxmind.geoip2</groupId>
                         <artifactId>geoip2</artifactId>
-                        <version>2.1.0</version>
+                        <version>2.12.0</version>
                         <scope>compile</scope>
                 </dependency>
         </dependencies>

--- a/src/main/java/com/spuul/hive/GeoIP2.java
+++ b/src/main/java/com/spuul/hive/GeoIP2.java
@@ -86,6 +86,7 @@ value = "_FUNC_(ip,attribute,database) - looks a property for an IP address from
 public class GeoIP2 extends GenericUDF {
 
         private ObjectInspectorConverters.Converter[] converters;
+        private DatabaseReader reader;
 
         /**
          * Initialize this UDF.
@@ -129,16 +130,18 @@ public class GeoIP2 extends GenericUDF {
                 String attributeName = ((Text) converters[1].convert(arguments[1].get())).toString();
                 String databaseName = ((Text) converters[2].convert(arguments[2].get())).toString();
 
-                //Just in case there are more than one database filename attached.
-                //We will just assume that two file with same filename are identical.
-                File database = new File(databaseName);
-
                 String retVal = "";
 
                 try {
-                        // This creates the DatabaseReader object, which should be reused across
-                        // lookups.
-                        DatabaseReader reader = new DatabaseReader.Builder(database).build();
+                        if (reader == null) {
+                                //Just in case there are more than one database filename attached.
+                                //We will just assume that two file with same filename are identical.
+                                File database = new File(databaseName);
+                                // This creates the DatabaseReader object, which should be reused across
+                                // lookups.
+                                reader = new DatabaseReader.Builder(database).build();
+                        }
+
                         String databaseType = reader.getMetadata().getDatabaseType();
                         InetAddress ipAddress = InetAddress.getByName(ip);
 


### PR DESCRIPTION
For some unknown reason Hive add their own obsolete version of the maxmind geoip db jar in the classpath. That causes classpath conflicts and breaks the UDF completely - addressed this with Maven shading.
Also, to optimise performance a bit, we reuse the DatabaseReader object - initialization with GeoIP v2 databases adds significant overhead.